### PR TITLE
V 0.4.2 add distinct_threshold to etl_qa_pipeline

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: apde
 Type: Package
 Title: Common functions used in APDE's work
-Version: 0.4.1
+Version: 0.4.2
 Author@R: c(
   person("Alastair", "Matheson", email = "alastair.matheson@kingcounty.gov", role = c("aut", "cre")))
 Author: Alastair Matheson [aut, cre]

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -62,6 +62,10 @@
 #' in proportions. Permissible range is [0, 100]. Default is \code{abs_threshold = 3}.
 #' @param rel_threshold Numeric threshold for flagging relative percentage changes 
 #' in means and medians. Permissible range is [0, 100]. Default is \code{rel_threshold = 2}.
+#' @param distinct_threshold Minimum number of distinct values needed for 
+#' calculating the minimum, mean, median, and maximum values. If the number of 
+#' distinct values is under this threshold, it will be treated as a categorical. Default is 
+#' \code{distinct_threshold = 1}.
 #'
 #' @return A list containing the final results from the ETL QA pipeline. Specifically, it includes:
 #'   \item{config}{Configuration settings used for the analysis}
@@ -161,7 +165,8 @@ etl_qa_run_pipeline <- function(connection = NULL,
                                 digits_mean = 3,
                                 digits_prop = 3,
                                 abs_threshold = 3,
-                                rel_threshold = 2) {
+                                rel_threshold = 2, 
+                                distinct_threshold = 1) {
   # Set visible bindings for global variables
   
   # Capture the name of the data source if it's an R data.table/data.frame (annoying hack to extract name from within a list) ----
@@ -299,7 +304,8 @@ etl_qa_run_pipeline <- function(connection = NULL,
     digits_mean = digits_mean,
     digits_prop = digits_prop,
     abs_threshold = abs_threshold,
-    rel_threshold = rel_threshold
+    rel_threshold = rel_threshold, 
+    distinct_threshold  = distinct_threshold
   )
   
   # Step 2: Initial QA results ----
@@ -373,6 +379,8 @@ etl_qa_run_pipeline <- function(connection = NULL,
 #' @param digits_prop Integer specifying decimal places for proportion rounding
 #' @param abs_threshold Numeric threshold for flagging absolute changes
 #' @param rel_threshold Numeric threshold for flagging relative changes
+#' @param distinct_threshold Minimum number of distinct values needed for 
+#' calculating the minimum, median, and maximum values.
 #'
 #' @details
 #' This is an \emph{internal function} accessible only by use of \code{:::}, for example, 
@@ -457,7 +465,8 @@ etl_qa_setup_config <- function(data_source_type,
                                 digits_mean = 0,
                                 digits_prop = 3,
                                 abs_threshold = 3,
-                                rel_threshold = 2) {
+                                rel_threshold = 2, 
+                                distinct_threshold = 1) {
   # Set visible bindings for global variables
   
   # Capture the name of the data.table/data.frame and add to params (need to do first, before any arguments evaluated or modified)
@@ -479,7 +488,7 @@ etl_qa_setup_config <- function(data_source_type,
     }
   } else {
     output_directory <- getwd()
-    warning("\U00026A0\nNo output_directory specified. Using current working directory: ", output_directory)
+    warning("\U00026A0\nNo output_directory specified. Using current working directory: ", output_directory, ".")
   }
   
   # Validate check_chi
@@ -500,7 +509,8 @@ etl_qa_setup_config <- function(data_source_type,
     digits_mean = digits_mean,
     digits_prop = digits_prop,
     abs_threshold = abs_threshold,
-    rel_threshold = rel_threshold
+    rel_threshold = rel_threshold, 
+    distinct_threshold = distinct_threshold 
   )
   
   # Add specific configurations based on data_source_type
@@ -575,10 +585,10 @@ etl_qa_setup_config <- function(data_source_type,
 #'
 #' @return A list of raw analytic output. The table structure may differ slightly depending on the original data_source. The list items include:
 #'   \item{missing_data}{The proportion of missing data for each variable and time point}
-#'   \item{vals_continuous}{The minimum, median, mean, and maximum for all numeric variables with > 6 distinct values}
-#'   \item{vals_date}{The minimum, median, and maximum for all date / datetime variables with > 6 distinct values}
+#'   \item{vals_continuous}{The minimum, median, mean, and maximum for all numeric variables with >= your specified \code{distinct_threshold} unique values}
+#'   \item{vals_date}{The minimum, median, and maximum for all date / datetime variables with >= your specified \code{distinct_threshold} unique values}
 #'   \item{vals_categorical}{A frequency table of the top 8 most frequent values 
-#'         of categorical variable (and numerics or dates with <= 6 distinct values) PLUS a rows for \code{NA} 
+#'         of categorical variable (and numerics or dates with < your specified \code{distinct_threshold} distinct values) PLUS a rows for \code{NA} 
 #'         PLUS a row for all 'Other values'}
 #'   \item{chi_standards}{Comparison of CHI (Community Health Indicator) variables values with those expected based on \code{rads.data::misc_chi_byvars}}
 #'
@@ -711,7 +721,7 @@ process_r_dataframe <- function(config) {
   missing_data[, varname := as.character(varname)]
   
   # Calculate summary statistics for continuous variables ----
-  numeric_cols <- setdiff(names(dt)[sapply(dt, function(x) is.numeric(x) && length(unique(x)) > 6)], config$time_var) # identify numerics with > 6 values
+  numeric_cols <- setdiff(names(dt)[sapply(dt, function(x) is.numeric(x) && length(unique(x)) >= config$distinct_threshold)], config$time_var) # identify numerics with >= distinct_threshold unique values 
   
   if(length(numeric_cols) > 0){
     dt[, (numeric_cols) := lapply(.SD, as.double), .SDcols = numeric_cols]
@@ -728,7 +738,7 @@ process_r_dataframe <- function(config) {
     }
   
   # Calculate summary statistics for datetime ----
-  date_cols <- setdiff(names(dt)[sapply(dt, function(x) (inherits(x, "Date") || inherits(x, "POSIXt") || inherits(x, "POSIXct")) && length(unique(x)) > 6)], config$time_var)
+  date_cols <- setdiff(names(dt)[sapply(dt, function(x) (inherits(x, "Date") || inherits(x, "POSIXt") || inherits(x, "POSIXct")) && length(unique(x)) >= config$distinct_threshold)], config$time_var)
   
   if(length(date_cols) > 0){
     dt[, (date_cols) := lapply(.SD, as.Date), .SDcols = date_cols] # convert datetime to actual date
@@ -746,7 +756,7 @@ process_r_dataframe <- function(config) {
   }
   
   # Calculate categorical value frequencies ----
-  categorical_cols <- setdiff(names(dt), c(config$time_var, numeric_cols, date_cols)) # categorical and numeric with <= 6 unique values
+  categorical_cols <- setdiff(names(dt), c(config$time_var, numeric_cols, date_cols)) # categorical and numeric with <= distinct_threshol unique values
   
   if(length(categorical_cols) > 0){
     dt[, (categorical_cols) := lapply(.SD, as.character), .SDcols = categorical_cols]
@@ -766,10 +776,10 @@ process_r_dataframe <- function(config) {
     # Get all gold standard CHI varnames and groups
     chi_std <- rads.data::misc_chi_byvars[, list(varname, group, chi = 1L)]
     
-    # Identify all chi variables that are in the data.frame/data.table
-    chi_dtvars <- unique(intersect(names(dt), unique(chi_std$varname)))
-    chi_dtvars <- setdiff(chi_dtvars, 'chi_year') # remove chi_year because continuous
-    
+    # Identify all categorical chi variables that are in the data.frame/data.table
+    categorical_cols <- setdiff(names(dt), c(config$time_var, numeric_cols, date_cols))
+    chi_dtvars <- unique(intersect(categorical_cols, unique(chi_std$varname)))
+
     # Limit CHI gold standard table to just variables that are in the data.frame/data.table
     chi_std <- chi_std[varname %in% chi_dtvars]
     
@@ -962,7 +972,7 @@ process_sql_server <- function(config) {
     # Get all gold standard CHI varnames and groups
     chi_std <- rads.data::misc_chi_byvars[, list(varname, group, chi = 1L)]
     
-    # Limit chi_std to varnames in frequency table
+    # Limit chi_std to categorical variables in frequency table
     chi_std <- chi_std[varname %in% unique(categorical_freq$varname)]
     
     # Limit frequency table to CHI varnames
@@ -1291,7 +1301,7 @@ generate_numeric_query <- function(config) {
     filtered_columns AS (
       SELECT varname
       FROM column_stats
-      WHERE distinct_count > 6
+      WHERE distinct_count >= {config$distinct_threshold}
     ),
     stats AS (
       SELECT
@@ -1399,7 +1409,7 @@ generate_date_query <- function(config) {
     filtered_columns AS (
       SELECT varname
       FROM column_stats
-      WHERE distinct_count > 6
+      WHERE distinct_count >= {config$distinct_threshold}
     ),
     stats AS (
       SELECT

--- a/man/etl_qa_initial_results.Rd
+++ b/man/etl_qa_initial_results.Rd
@@ -12,10 +12,10 @@ etl_qa_initial_results(config)
 \value{
 A list of raw analytic output. The table structure may differ slightly depending on the original data_source. The list items include:
   \item{missing_data}{The proportion of missing data for each variable and time point}
-  \item{vals_continuous}{The minimum, median, mean, and maximum for all numeric variables with > 6 distinct values}
-  \item{vals_date}{The minimum, median, and maximum for all date / datetime variables with > 6 distinct values}
+  \item{vals_continuous}{The minimum, median, mean, and maximum for all numeric variables with >= your specified \code{distinct_threshold} unique values}
+  \item{vals_date}{The minimum, median, and maximum for all date / datetime variables with >= your specified \code{distinct_threshold} unique values}
   \item{vals_categorical}{A frequency table of the top 8 most frequent values 
-        of categorical variable (and numerics or dates with <= 6 distinct values) PLUS a rows for \code{NA} 
+        of categorical variable (and numerics or dates with < your specified \code{distinct_threshold} distinct values) PLUS a rows for \code{NA} 
         PLUS a row for all 'Other values'}
   \item{chi_standards}{Comparison of CHI (Community Health Indicator) variables values with those expected based on \code{rads.data::misc_chi_byvars}}
 }

--- a/man/etl_qa_run_pipeline.Rd
+++ b/man/etl_qa_run_pipeline.Rd
@@ -12,7 +12,8 @@ etl_qa_run_pipeline(
   digits_mean = 3,
   digits_prop = 3,
   abs_threshold = 3,
-  rel_threshold = 2
+  rel_threshold = 2,
+  distinct_threshold = 1
 )
 }
 \arguments{
@@ -77,6 +78,11 @@ in proportions. Permissible range is [0, 100]. Default is \code{abs_threshold = 
 
 \item{rel_threshold}{Numeric threshold for flagging relative percentage changes 
 in means and medians. Permissible range is [0, 100]. Default is \code{rel_threshold = 2}.}
+
+\item{distinct_threshold}{Minimum number of distinct values needed for 
+calculating the minimum, mean, median, and maximum values. If the number of 
+distinct values is under this threshold, it will be treated as a categorical. Default is 
+\code{distinct_threshold = 1}.}
 }
 \value{
 A list containing the final results from the ETL QA pipeline. Specifically, it includes:

--- a/man/etl_qa_setup_config.Rd
+++ b/man/etl_qa_setup_config.Rd
@@ -12,7 +12,8 @@ etl_qa_setup_config(
   digits_mean = 0,
   digits_prop = 3,
   abs_threshold = 3,
-  rel_threshold = 2
+  rel_threshold = 2,
+  distinct_threshold = 1
 )
 }
 \arguments{
@@ -31,6 +32,9 @@ etl_qa_setup_config(
 \item{abs_threshold}{Numeric threshold for flagging absolute changes}
 
 \item{rel_threshold}{Numeric threshold for flagging relative changes}
+
+\item{distinct_threshold}{Minimum number of distinct values needed for 
+calculating the minimum, median, and maximum values.}
 }
 \value{
 An S3 object of class "qa_data_config", which is a list containing the configuration settings.

--- a/vignettes/etl_qa_run_pipeline.qmd
+++ b/vignettes/etl_qa_run_pipeline.qmd
@@ -52,7 +52,7 @@ This graph shows basic statistics for *date* variables at each time period. Note
 
 ### Figure 2c: Categorical frequencies
 
-This graph shows the proportion of observations with a given value at each time period. It displays the top eight most frequent values PLUS missing values (dotted line) PLUS all other values combined and labeled 'Other values'. Note that numeric and date variables with six or fewer distinct values will be treated as a categorical.<br><br> ![](etl_qa_categorical.jpg){#fig-categorical}
+This graph shows the proportion of observations with a given value at each time period. It displays the top eight most frequent values PLUS missing values (dotted line) PLUS all other values combined and labeled 'Other values'. Note that numeric and date variables with fewer than or equal to your specified `distinct_threshold` unique values will be treated as categorical. This threshold (default = 1) is particularly useful for controlling how ordinal variables or numeric codes with limited values are analyzed.<br><br> ![](etl_qa_categorical.jpg){#fig-categorical}
 
 ## Tables
 
@@ -113,7 +113,7 @@ keepers <- (keepers - 4):(keepers + 4)
 pretty_kable(sample_chi[keepers])
 ```
 
-Now that you've learned what this function can can, let's learn how to use it!
+Now that you've learned what this function can do, let's learn how to use it!
 
 # Setting up the environment
 
@@ -135,7 +135,7 @@ Character string specifying the type of data source. Must be one of `'r_datafram
 
 ## `connection`
 
-A DBIConnection object.<br>**Required only when `data_source_type = 'sql_server'`**.
+A DBI Connection object.<br>**Required only when `data_source_type = 'sql_server'`**.
 
 ## `data_params`
 
@@ -145,7 +145,7 @@ List of data related parameters specific to the data source. Not all parameters 
 
     ### `data_params$check_chi`
 
-    Logical vector of length 1. When `check_chi = TRUE`, function will add any available CHI related variables to `data_params$cols` and will assess whether their values align with standards in `rads.data::misc_chi_byvars`.<br>Default is `check_chi = FALSE`.
+    Logical vector of length 1. When `check_chi = TRUE`, function will add any available CHI related variables to `data_params$cols` and, if they are categorical, will assess whether their values align with standards in `rads.data::misc_chi_byvars`.<br>Default is `check_chi = FALSE`.
 
 -   
 
@@ -215,6 +215,10 @@ Numeric threshold for flagging *absolute* percentage changes in *proportions.* P
 
 Numeric threshold for flagging *relative* percentage changes in *means* and *medians*. Permissible range is \[0, 100\].<br>Default is `rel_threshold = 2`.
 
+## `distinct_threshold`
+
+Integer specifying the minimum number of unique values needed for a numeric or date variable to be analyzed as such. Variables with fewer distinct values will be treated as categoricals.<br>Default is `distinct_threshold = 1`.
+
 # Examples
 
 As stated above, this function can QA data in SQL Server, a local data.table/ data.frame, or from `rads`. Here we provide an example of each method to QA the same data source. Since all three methods provide identical output, we will only explore the SQL Server QA in detail knowing that it is generalizable.
@@ -234,21 +238,26 @@ qaSQL <- etl_qa_run_pipeline(
             'num_prev_cesarean', 'mother_date_of_birth'), 
     check_chi = TRUE
   ), 
+  distinct_threshold = 6,
   output_directory = tempdir()
 )
 ```
 
-Since we set `check_chi = TRUE`, the function pulled in all available CHI related variables and compared them to known standards. In this case, it identified three deviations between the birth data and the CHI standards. However, these are known issues that are related to conception of the CHI variables rather than a data processing issue, so there is a `note` letting the user know not to worry about the discrepancy. I've hidden this message for the examples that follow to simplify this vignette.
+Since we set `check_chi = TRUE`, the function pulled in all available CHI related variables and compared them to known standards. In this case, it identified two deviations between the birth data and the CHI standards. However, these are known issues that are related to conception of the CHI variables rather than a data processing issue, so there is a `note` letting the user know not to worry about the discrepancy. I've hidden this message for the examples that follow to simplify this vignette.
 
 The final statement asks the user to check their `output_directory`, which is `tempdir()`. Let's see what is saved there:
 
-```{r echo=TRUE, results='show', warning=TRUE, message=TRUE}
+```{r echo=TRUE, results='hide', warning=FALSE, message=FALSE}
 list.files(tempdir())
 ```
 
--   `birth.final_analytic_qa_missing_2024_09_30.pdf` contains graphs like the one showin in Figure 1.
--   `birth.final_analytic_qa_values_2024_09_30.pdf` contains the graphs like those in Figures 2a, 2b, and 2c.
--   `birth.final_analytic_qa_2024_09_30.xlsx` contains three worksheeets, one for each of the three tables given in the Tables section above.
+```{r echo=FALSE, results='show', warning=FALSE, message=FALSE}
+list.files(tempdir(),  pattern = '.pdf|.xlsx')
+```
+
+-   **`r list.files(tempdir(), pattern = 'qa_missing')`** contains graphs like the one showin in Figure 1.
+-   **`r list.files(tempdir(), pattern = 'qa_value')`** contains the graphs like those in Figures 2a, 2b, and 2c.
+-   **`r list.files(tempdir(), pattern = '.xlsx')`** contains three worksheeets, one for each of the three tables given in the Tables section above.
 
 We also saved the output as the object `qaSQL`. Let's confirm that what was written about the returned object in the Sneak peek section above was correct:
 
@@ -281,6 +290,7 @@ qaDF <- etl_qa_run_pipeline(
              'num_prev_cesarean', 'mother_date_of_birth'), 
     check_chi = TRUE
   ), 
+  distinct_threshold = 6,
   output_directory = tempdir()
 )
 ```
@@ -300,6 +310,7 @@ qaRADS <- etl_qa_run_pipeline(
     kingco = FALSE,
     check_chi = TRUE
   ),
+  distinct_threshold = 6,
   output_directory = tempdir()
 )
 ```
@@ -307,8 +318,8 @@ qaRADS <- etl_qa_run_pipeline(
 ## Confirm that the results from each method are identical
 
 ```{r echo=TRUE, results='show', warning=TRUE, message=TRUE}
-identical(qaDF$final, qaSQL$final)
-identical(qaDF$final, qaRADS$final)
+isTRUE(all.equal(qaDF$final, qaSQL$final))
+isTRUE(all.equal(qaDF$final, qaRADS$final))
 ```
 
 # Conclusion


### PR DESCRIPTION
- bump to version 0.4.2
- `distinct_threshold` added because had errors where there were dates that
 did not vary (e.g., a creation_date that was consistent in dataset) and
 previous hardcoded threshold of 6 causes errors.
- updated `etl_qa_run_pipeline` vignette for new parameter
- Previously comparison to CHI standards in SQL was only for
 categorical variables, whereas the code for data.frames (from RADS or
 other sources) compared all CHI variables to their standards. NOW
 changed so that the data.frame code also only compares to categoricals.
 Improvement because variables like chi_age are bound to have some
 missing values because they can range from 0-100. These would now be
 excluded.
